### PR TITLE
fix: preserve v-lazy-show wrapper when children contain structural directives

### DIFF
--- a/playgrounds/vite/src/App.vue
+++ b/playgrounds/vite/src/App.vue
@@ -4,7 +4,7 @@ import HelloWorld from './HelloWorld.vue'
 
 const enabled = ref(false)
 
-const foo = ref(true)
+const innerIf = ref(true)
 
 function handler(msg?: string) {
   // eslint-disable-next-line no-console
@@ -28,7 +28,7 @@ function handler(msg?: string) {
   <hr>
   <div v-lazy-show="enabled">
     <HelloWorld msg="v-lazy-show" :handler="handler" />
-    <div v-if="foo">
+    <div v-if="innerIf">
       <HelloWorld msg="inner v-if in v-lazy-show" />
     </div>
   </div>

--- a/playgrounds/vite/src/App.vue
+++ b/playgrounds/vite/src/App.vue
@@ -4,6 +4,8 @@ import HelloWorld from './HelloWorld.vue'
 
 const enabled = ref(false)
 
+const foo = ref(true)
+
 function handler(msg?: string) {
   // eslint-disable-next-line no-console
   console.log(msg || '111')
@@ -26,6 +28,9 @@ function handler(msg?: string) {
   <hr>
   <div v-lazy-show="enabled">
     <HelloWorld msg="v-lazy-show" :handler="handler" />
+    <div v-if="foo">
+      <HelloWorld msg="inner v-if in v-lazy-show" />
+    </div>
   </div>
   <div v-show="enabled">
     <HelloWorld msg="v-show" />

--- a/playgrounds/vite/src/App.vue
+++ b/playgrounds/vite/src/App.vue
@@ -6,6 +6,8 @@ const enabled = ref(false)
 
 const innerIf = ref(true)
 
+const innerElseIf = ref(false)
+
 function handler(msg?: string) {
   // eslint-disable-next-line no-console
   console.log(msg || '111')
@@ -30,6 +32,12 @@ function handler(msg?: string) {
     <HelloWorld msg="v-lazy-show" :handler="handler" />
     <div v-if="innerIf">
       <HelloWorld msg="inner v-if in v-lazy-show" />
+    </div>
+    <div v-else-if="innerElseIf">
+      <HelloWorld msg="inner v-else-if in v-lazy-show" />
+    </div>
+    <div v-else>
+      <HelloWorld msg="inner v-else in v-lazy-show" />
     </div>
   </div>
   <div v-show="enabled">

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,28 @@ export const transformLazyShow = createStructuralDirectiveTransform(
     _context.replaceNode = (node) => {
       _context.parent!.children[_context.childIndex] = _context.currentNode = node
     }
+    _context.removeNode = (node) => {
+      const list = _context.parent!.children
+      const removalIndex = node
+        ? list.indexOf(node)
+        : _context.currentNode
+          ? _context.childIndex
+          : -1
+
+      if (removalIndex < 0)
+        throw new Error('node being removed is not a child of current parent')
+
+      if (!node || node === _context.currentNode) {
+        _context.currentNode = null
+        _context.onNodeRemoved()
+      }
+      else if (_context.childIndex > removalIndex) {
+        _context.childIndex--
+        _context.onNodeRemoved()
+      }
+
+      list.splice(removalIndex, 1)
+    }
 
     context.replaceNode(<TemplateChildNode><unknown>wrapNode)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { TemplateChildNode } from '@vue/compiler-core'
+import type { TemplateChildNode, TransformContext } from '@vue/compiler-core'
 import {
   CREATE_COMMENT,
   createCallExpression,
@@ -116,31 +116,41 @@ export const transformLazyShow = createStructuralDirectiveTransform(
       name: DIRECTIVE_NODES.SHOW,
     })
 
-    const _context = Object.assign({}, context)
-    _context.replaceNode = (node) => {
-      _context.parent!.children[_context.childIndex] = _context.currentNode = node
-    }
-    _context.removeNode = (node) => {
-      const list = _context.parent!.children
-      const removalIndex = node
-        ? list.indexOf(node)
-        : _context.currentNode
-          ? _context.childIndex
-          : -1
+    // Re-traverse nested children with a local transform context.
+    // `replaceNode()` and `removeNode()` are copied here because Vue's original
+    // implementations close over the outer compiler context, so reusing them
+    // would mutate the parent traversal instead of this nested subtree.
+    const _context: TransformContext = {
+      ...context,
+      childIndex: 0,
+      currentNode: node,
+      parent: node,
+      replaceNode(node) {
+        _context.parent!.children[_context.childIndex] = _context.currentNode = node
+      },
+      removeNode(node) {
+        const list = _context.parent!.children
+        const removalIndex = node
+          ? list.indexOf(node)
+          : _context.currentNode
+            ? _context.childIndex
+            : -1
 
-      if (removalIndex < 0)
-        throw new Error('node being removed is not a child of current parent')
+        if (!node || node === _context.currentNode) {
+        // current node removed
+          _context.currentNode = null
+          _context.onNodeRemoved()
+        }
+        else {
+          // sibling node removed
+          if (_context.childIndex > removalIndex) {
+            _context.childIndex--
+            _context.onNodeRemoved()
+          }
+        }
 
-      if (!node || node === _context.currentNode) {
-        _context.currentNode = null
-        _context.onNodeRemoved()
-      }
-      else if (_context.childIndex > removalIndex) {
-        _context.childIndex--
-        _context.onNodeRemoved()
-      }
-
-      list.splice(removalIndex, 1)
+        _context.parent!.children.splice(removalIndex, 1)
+      },
     }
 
     context.replaceNode(<TemplateChildNode><unknown>wrapNode)

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,10 @@ export const transformLazyShow = createStructuralDirectiveTransform(
     })
 
     const _context = Object.assign({}, context)
+    _context.replaceNode = (node) => {
+      _context.parent!.children[_context.childIndex] = _context.currentNode = node
+    }
+
     context.replaceNode(<TemplateChildNode><unknown>wrapNode)
 
     return () => {

--- a/test/cases/inner-v-else-if/input.html
+++ b/test/cases/inner-v-else-if/input.html
@@ -1,0 +1,6 @@
+<span v-lazy-show="foo">
+  <span>Foo</span>
+  <span v-if="bar">If</span>
+  <span v-else-if="baz">Else If</span>
+  <span v-else>Else</span>
+</span>

--- a/test/cases/inner-v-else-if/output.csr.js
+++ b/test/cases/inner-v-else-if/output.csr.js
@@ -1,0 +1,18 @@
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, createElementVNode as _createElementVNode, vShow as _vShow, withDirectives as _withDirectives } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_cache._lazyshow1 || _ctx.foo)
+    ? (_cache._lazyshow1 = true, (_openBlock(), _createElementBlock(_Fragment, null, [
+        _withDirectives(_createElementVNode("span", null, [
+          _createElementVNode("span", null, "Foo"),
+          (_ctx.bar)
+            ? (_openBlock(), _createElementBlock("span", { key: 0 }, "If"))
+            : (_ctx.baz)
+              ? (_openBlock(), _createElementBlock("span", { key: 1 }, "Else If"))
+              : (_openBlock(), _createElementBlock("span", { key: 2 }, "Else"))
+        ], 512 /* NEED_PATCH */), [
+          [_vShow, _ctx.foo]
+        ])
+      ], 64 /* STABLE_FRAGMENT */)))
+    : _createCommentVNode("v-show-if", true)
+}

--- a/test/cases/inner-v-else-if/output.ssr.js
+++ b/test/cases/inner-v-else-if/output.ssr.js
@@ -1,12 +1,12 @@
-import { createVNode as _createVNode, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode } from "vue"
+import { mergeProps as _mergeProps, createVNode as _createVNode } from "vue"
 import { ssrRenderAttrs as _ssrRenderAttrs } from "vue/server-renderer"
 
 export function ssrRender(_ctx, _push, _parent, _attrs) {
   if (_ctx.foo) {
     _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}><span>Foo</span>`)
-    if (_ctx.bar) {
+    if (_ctx.innerIf) {
       _push(`<span>If</span>`)
-    } else if (_ctx.baz) {
+    } else if (_ctx.innerElseIf) {
       _push(`<span>Else If</span>`)
     } else {
       _push(`<span>Else</span>`)

--- a/test/cases/inner-v-else-if/output.ssr.js
+++ b/test/cases/inner-v-else-if/output.ssr.js
@@ -1,0 +1,18 @@
+import { createVNode as _createVNode, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode } from "vue"
+import { ssrRenderAttrs as _ssrRenderAttrs } from "vue/server-renderer"
+
+export function ssrRender(_ctx, _push, _parent, _attrs) {
+  if (_ctx.foo) {
+    _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}><span>Foo</span>`)
+    if (_ctx.bar) {
+      _push(`<span>If</span>`)
+    } else if (_ctx.baz) {
+      _push(`<span>Else If</span>`)
+    } else {
+      _push(`<span>Else</span>`)
+    }
+    _push(`</span>`)
+  } else {
+    _push(`<!---->`)
+  }
+}

--- a/test/cases/inner-v-else/input.html
+++ b/test/cases/inner-v-else/input.html
@@ -1,0 +1,5 @@
+<span v-lazy-show="foo">
+  <span>Foo</span>
+  <span v-if="bar">If</span>
+  <span v-else>Else</span>
+</span>

--- a/test/cases/inner-v-else/input.html
+++ b/test/cases/inner-v-else/input.html
@@ -1,5 +1,5 @@
 <span v-lazy-show="foo">
   <span>Foo</span>
-  <span v-if="bar">If</span>
+  <span v-if="innerIf">If</span>
   <span v-else>Else</span>
 </span>

--- a/test/cases/inner-v-else/output.csr.js
+++ b/test/cases/inner-v-else/output.csr.js
@@ -5,7 +5,7 @@ export function render(_ctx, _cache) {
     ? (_cache._lazyshow1 = true, (_openBlock(), _createElementBlock(_Fragment, null, [
         _withDirectives(_createElementVNode("span", null, [
           _createElementVNode("span", null, "Foo"),
-          (_ctx.bar)
+          (_ctx.innerIf)
             ? (_openBlock(), _createElementBlock("span", { key: 0 }, "If"))
             : (_openBlock(), _createElementBlock("span", { key: 1 }, "Else"))
         ], 512 /* NEED_PATCH */), [

--- a/test/cases/inner-v-else/output.csr.js
+++ b/test/cases/inner-v-else/output.csr.js
@@ -1,0 +1,16 @@
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, createElementVNode as _createElementVNode, vShow as _vShow, withDirectives as _withDirectives } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_cache._lazyshow1 || _ctx.foo)
+    ? (_cache._lazyshow1 = true, (_openBlock(), _createElementBlock(_Fragment, null, [
+        _withDirectives(_createElementVNode("span", null, [
+          _createElementVNode("span", null, "Foo"),
+          (_ctx.bar)
+            ? (_openBlock(), _createElementBlock("span", { key: 0 }, "If"))
+            : (_openBlock(), _createElementBlock("span", { key: 1 }, "Else"))
+        ], 512 /* NEED_PATCH */), [
+          [_vShow, _ctx.foo]
+        ])
+      ], 64 /* STABLE_FRAGMENT */)))
+    : _createCommentVNode("v-show-if", true)
+}

--- a/test/cases/inner-v-else/output.ssr.js
+++ b/test/cases/inner-v-else/output.ssr.js
@@ -1,0 +1,16 @@
+import { createVNode as _createVNode, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode } from "vue"
+import { ssrRenderAttrs as _ssrRenderAttrs } from "vue/server-renderer"
+
+export function ssrRender(_ctx, _push, _parent, _attrs) {
+  if (_ctx.foo) {
+    _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}><span>Foo</span>`)
+    if (_ctx.bar) {
+      _push(`<span>If</span>`)
+    } else {
+      _push(`<span>Else</span>`)
+    }
+    _push(`</span>`)
+  } else {
+    _push(`<!---->`)
+  }
+}

--- a/test/cases/inner-v-if-2/input.html
+++ b/test/cases/inner-v-if-2/input.html
@@ -1,6 +1,4 @@
 <span v-lazy-show="foo">
   <span>Foo</span>
   <span v-if="innerIf">If</span>
-  <span v-else-if="innerElseIf">Else If</span>
-  <span v-else>Else</span>
 </span>

--- a/test/cases/inner-v-if-2/output.csr.js
+++ b/test/cases/inner-v-if-2/output.csr.js
@@ -7,9 +7,7 @@ export function render(_ctx, _cache) {
           _createElementVNode("span", null, "Foo"),
           (_ctx.innerIf)
             ? (_openBlock(), _createElementBlock("span", { key: 0 }, "If"))
-            : (_ctx.innerElseIf)
-              ? (_openBlock(), _createElementBlock("span", { key: 1 }, "Else If"))
-              : (_openBlock(), _createElementBlock("span", { key: 2 }, "Else"))
+            : _createCommentVNode("v-if", true)
         ], 512 /* NEED_PATCH */), [
           [_vShow, _ctx.foo]
         ])

--- a/test/cases/inner-v-if-2/output.ssr.js
+++ b/test/cases/inner-v-if-2/output.ssr.js
@@ -7,7 +7,7 @@ export function ssrRender(_ctx, _push, _parent, _attrs) {
     if (_ctx.innerIf) {
       _push(`<span>If</span>`)
     } else {
-      _push(`<span>Else</span>`)
+      _push(`<!---->`)
     }
     _push(`</span>`)
   } else {

--- a/test/cases/inner-v-if/input.html
+++ b/test/cases/inner-v-if/input.html
@@ -1,0 +1,3 @@
+<span v-lazy-show="foo">
+  <span v-if="bar">Hello</span>
+</span>

--- a/test/cases/inner-v-if/input.html
+++ b/test/cases/inner-v-if/input.html
@@ -1,3 +1,4 @@
 <span v-lazy-show="foo">
-  <span v-if="bar">Hello</span>
+  <span>Foo</span>
+  <span v-if="bar">Bar</span>
 </span>

--- a/test/cases/inner-v-if/input.html
+++ b/test/cases/inner-v-if/input.html
@@ -1,4 +1,3 @@
 <span v-lazy-show="foo">
-  <span>Foo</span>
-  <span v-if="bar">Bar</span>
+  <span v-if="innerIf">If</span>
 </span>

--- a/test/cases/inner-v-if/output.csr.js
+++ b/test/cases/inner-v-if/output.csr.js
@@ -4,6 +4,6 @@ const _hoisted_1 = { key: 0 }
 
 export function render(_ctx, _cache) {
   return (_ctx.bar)
-    ? (_openBlock(), _createElementBlock("span", _hoisted_1, "Hello"))
+    ? (_openBlock(), _createElementBlock("span", _hoisted_1, "Bar"))
     : _createCommentVNode("v-if", true)
 }

--- a/test/cases/inner-v-if/output.csr.js
+++ b/test/cases/inner-v-if/output.csr.js
@@ -4,9 +4,8 @@ export function render(_ctx, _cache) {
   return (_cache._lazyshow1 || _ctx.foo)
     ? (_cache._lazyshow1 = true, (_openBlock(), _createElementBlock(_Fragment, null, [
         _withDirectives(_createElementVNode("span", null, [
-          _createElementVNode("span", null, "Foo"),
-          (_ctx.bar)
-            ? (_openBlock(), _createElementBlock("span", { key: 0 }, "Bar"))
+          (_ctx.innerIf)
+            ? (_openBlock(), _createElementBlock("span", { key: 0 }, "If"))
             : _createCommentVNode("v-if", true)
         ], 512 /* NEED_PATCH */), [
           [_vShow, _ctx.foo]

--- a/test/cases/inner-v-if/output.csr.js
+++ b/test/cases/inner-v-if/output.csr.js
@@ -1,0 +1,9 @@
+import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, createElementVNode as _createElementVNode, vShow as _vShow, withDirectives as _withDirectives } from "vue"
+
+const _hoisted_1 = { key: 0 }
+
+export function render(_ctx, _cache) {
+  return (_ctx.bar)
+    ? (_openBlock(), _createElementBlock("span", _hoisted_1, "Hello"))
+    : _createCommentVNode("v-if", true)
+}

--- a/test/cases/inner-v-if/output.csr.js
+++ b/test/cases/inner-v-if/output.csr.js
@@ -1,9 +1,16 @@
 import { Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode, createElementVNode as _createElementVNode, vShow as _vShow, withDirectives as _withDirectives } from "vue"
 
-const _hoisted_1 = { key: 0 }
-
 export function render(_ctx, _cache) {
-  return (_ctx.bar)
-    ? (_openBlock(), _createElementBlock("span", _hoisted_1, "Bar"))
-    : _createCommentVNode("v-if", true)
+  return (_cache._lazyshow1 || _ctx.foo)
+    ? (_cache._lazyshow1 = true, (_openBlock(), _createElementBlock(_Fragment, null, [
+        _withDirectives(_createElementVNode("span", null, [
+          _createElementVNode("span", null, "Foo"),
+          (_ctx.bar)
+            ? (_openBlock(), _createElementBlock("span", { key: 0 }, "Bar"))
+            : _createCommentVNode("v-if", true)
+        ], 512 /* NEED_PATCH */), [
+          [_vShow, _ctx.foo]
+        ])
+      ], 64 /* STABLE_FRAGMENT */)))
+    : _createCommentVNode("v-show-if", true)
 }

--- a/test/cases/inner-v-if/output.ssr.js
+++ b/test/cases/inner-v-if/output.ssr.js
@@ -1,11 +1,11 @@
-import { createVNode as _createVNode, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode } from "vue"
+import { mergeProps as _mergeProps, createVNode as _createVNode } from "vue"
 import { ssrRenderAttrs as _ssrRenderAttrs } from "vue/server-renderer"
 
 export function ssrRender(_ctx, _push, _parent, _attrs) {
   if (_ctx.foo) {
-    _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}><span>Foo</span>`)
-    if (_ctx.bar) {
-      _push(`<span>Bar</span>`)
+    _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}>`)
+    if (_ctx.innerIf) {
+      _push(`<span>If</span>`)
     } else {
       _push(`<!---->`)
     }

--- a/test/cases/inner-v-if/output.ssr.js
+++ b/test/cases/inner-v-if/output.ssr.js
@@ -1,0 +1,16 @@
+import { createVNode as _createVNode, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode } from "vue"
+import { ssrRenderAttrs as _ssrRenderAttrs } from "vue/server-renderer"
+
+export function ssrRender(_ctx, _push, _parent, _attrs) {
+  if (_ctx.foo) {
+    _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}>`)
+    if (_ctx.bar) {
+      _push(`<span>Hello</span>`)
+    } else {
+      _push(`<!---->`)
+    }
+    _push(`</span>`)
+  } else {
+    _push(`<!---->`)
+  }
+}

--- a/test/cases/inner-v-if/output.ssr.js
+++ b/test/cases/inner-v-if/output.ssr.js
@@ -3,9 +3,9 @@ import { ssrRenderAttrs as _ssrRenderAttrs } from "vue/server-renderer"
 
 export function ssrRender(_ctx, _push, _parent, _attrs) {
   if (_ctx.foo) {
-    _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}>`)
+    _push(`<span${_ssrRenderAttrs(_mergeProps(_attrs, _attrs))}><span>Foo</span>`)
     if (_ctx.bar) {
-      _push(`<span>Hello</span>`)
+      _push(`<span>Bar</span>`)
     } else {
       _push(`<!---->`)
     }


### PR DESCRIPTION
Fixes #15

This fix was implemented with AI assistance. I am not deeply familiar with Vue compiler internals, so I cannot guarantee this is the optimal or most idiomatic approach.